### PR TITLE
setup.sh: install latexindent perl dependencies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -64,6 +64,26 @@ if [ "$scheme" != "full" ]; then
     texliveonfly
 fi
 
+# https://latexindentpl.readthedocs.io/en/latest/appendices.html#lst-alpine-install
+# Installing incompatible latexindent perl dependencies via apk
+apk --no-cache add \
+    perl-log-log4perl \
+    perl-log-dispatch \
+    perl-namespace-autoclean \
+    perl-specio \
+    perl-unicode-linebreak
+
+# Installing remaining latexindent perl dependencies via cpan
+apk --no-cache add curl wget make
+cd /usr/local/bin && \
+    curl -L https://cpanmin.us/ -o cpanm && \
+    chmod +x cpanm
+cpanm -n App::cpanminus
+cpanm -n File::HomeDir
+cpanm -n Params::ValidationCompiler
+cpanm -n YAML::Tiny
+cpanm -n Unicode::GCString
+
 echo "==> Clean up"
 rm -rf \
   /opt/texlive/texdir/install-tl \

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,7 @@ apk --no-cache add \
   perl-params-validationcompiler \
   perl-specio \
   perl-unicode-linebreak \
-  perl-yaml-tiny 
+  perl-yaml-tiny \
   py-pygments \
   python2 \
   python3 \

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,7 @@ apk --no-cache add \
   perl-params-validationcompiler \
   perl-specio \
   perl-unicode-linebreak \
-  perl-yaml-tiny
+  perl-yaml-tiny 
   py-pygments \
   python2 \
   python3 \

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,7 @@ retry() {
   done
 }
 
+head -1 /etc/apk/repositories | sed s'/alpine\/.*$/alpine\/edge\/testing/' >> /etc/apk/repositories 
 echo "==> Install system packages"
 apk --no-cache add \
   bash \
@@ -31,6 +32,15 @@ apk --no-cache add \
   graphviz \
   openjdk11-jre-headless \
   perl \
+  perl-app-cpanminus \
+  perl-file-homedir \
+  perl-log-log4perl \
+  perl-log-dispatch \
+  perl-namespace-autoclean \
+  perl-params-validationcompiler \
+  perl-specio \
+  perl-unicode-linebreak \
+  perl-yaml-tiny
   py-pygments \
   python2 \
   python3 \
@@ -63,26 +73,6 @@ if [ "$scheme" != "full" ]; then
     latexmk \
     texliveonfly
 fi
-
-# https://latexindentpl.readthedocs.io/en/latest/appendices.html#lst-alpine-install
-# Installing incompatible latexindent perl dependencies via apk
-apk --no-cache add \
-    perl-log-log4perl \
-    perl-log-dispatch \
-    perl-namespace-autoclean \
-    perl-specio \
-    perl-unicode-linebreak
-
-# Installing remaining latexindent perl dependencies via cpan
-apk --no-cache add curl wget make
-cd /usr/local/bin && \
-    curl -L https://cpanmin.us/ -o cpanm && \
-    chmod +x cpanm
-cpanm -n App::cpanminus
-cpanm -n File::HomeDir
-cpanm -n Params::ValidationCompiler
-cpanm -n YAML::Tiny
-cpanm -n Unicode::GCString
 
 echo "==> Clean up"
 rm -rf \


### PR DESCRIPTION
May be fix #1 but now I run these command in https://github.com/xu-cheng/texlive-action manually, but I think the setup should add in `setup.sh`

Appendices: https://latexindentpl.readthedocs.io/en/latest/appendices.html#lst-alpine-install 