### PR TITLE
Provide some support for cyrillic fonts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -79,6 +79,16 @@ if [ "$scheme" != "full" ]; then
     texliveonfly
 fi
 
+# Install additional fonts for full sheme
+if [ "$scheme" == "full" ]; then
+  apk --no-cache add \
+    msttcorefonts-installer \
+    fontconfig
+  update-ms-fonts
+  fc-cache -f
+  mktextfm larm1200
+fi
+
 echo "==> Clean up"
 rm -rf \
   /opt/texlive/texdir/install-tl \


### PR DESCRIPTION
I encountered two problems with cyrillic fonts with lualatex:
1. First, I get `Font \T2A/cmr/m/n/13=larm1200 at 12pt not loadable: metric data not found or bad`
This error [is solved](https://tex.stackexchange.com/questions/288678/compile-error-font-t2a-cmr-m-n-12-larm1200-at-12-0pt-not-loadable-metric-tfm) with `mktextfm larm1200` command
2. Second problem happens when I use TimesNewRoman: `Package fontspec Error: The font "TimesNewRoman" cannot be found`
This error [is solved](https://unix.stackexchange.com/questions/438257/how-to-install-microsoft-true-type-font-on-alpine-linux) with packages msttcorefonts-installer and fontconfig