### PR TITLE
Install git in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,7 @@ apk --no-cache add \
   fontconfig \
   ghostscript \
   gnupg \
+  git \
   graphviz \
   make \
   openjdk11-jre-headless \


### PR DESCRIPTION
Having git makes e.g. gitver possible, https://github.com/charlesbaynham/gitver/tree/master/gitver

This is currently my `pre_compile`:
```
          pre_compile: |
            apk --no-cache add git
            git config --system --add safe.directory /github/workspace
```

It would be nicer to not have to do either, but not sure where the `safe.directory` line would have to go, probably in https://github.com/xu-cheng/latex-action somewhere.